### PR TITLE
Исправлено подключение конфига i18n

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -122,8 +122,8 @@ const config: NuxtConfig = {
     },
   },
   i18n: {
-    langDir: 'lexicons',
-    restructureDir: 'src',
+    langDir: 'src/lexicons',
+    restructureDir: '.',
     defaultLocale: locales[0].code,
     detectBrowserLanguage: {
       fallbackLocale: locales[0].code,


### PR DESCRIPTION
Сейчас конфиг `i18n.config.ts` не подключается вообще. Из-за чего проблемы вроде некорректной плюрализации в русском языке

Проблема возникает из-за того, что `@nuxtjs/i18n` [составляет](https://github.com/nuxt-modules/i18n/blob/6bae00e7ad765ca3ec47ccbeb449b4da6790c7ac/src/layers.ts#L93) путь к файлу `i18n.config.ts` (как и к `langDir`) относительно опции `restructureDir`. Можно было просто убрать эту опцию и прописать в `langDir: src/lexicons`. Но это поведение сломается в `@nuxtjs/i18n@9`, так как `restructureDir` там [по умолчанию равен](https://i18n.nuxtjs.org/docs/api/options#restructuredir) `i18n`. Тогда не только путь к `i18n.config.ts` будет строиться относительно папки `i18n`, но и путь к переводам. Из-за чего нам придется менять файловую структуру проекта