### PR TITLE
Add global hotkeys for video player control

### DIFF
--- a/frontend/src/components/player/video.vue
+++ b/frontend/src/components/player/video.vue
@@ -3,6 +3,8 @@
 </template>
 
 <script setup lang="ts">
+import { useGlobalHotkeys } from '~/utils/use-global-hotkeys'
+
 const props = defineProps({
   uuid: {
     type: String,
@@ -26,6 +28,8 @@ const props = defineProps({
 
 const video = ref()
 const player = ref()
+
+useGlobalHotkeys(player)
 
 async function initPlayer() {
   if (!props.uuid) {

--- a/frontend/src/utils/use-global-hotkeys.ts
+++ b/frontend/src/utils/use-global-hotkeys.ts
@@ -1,0 +1,46 @@
+import { onMounted, onUnmounted } from 'vue'
+
+export function useGlobalHotkeys(player: any) {
+    // Check if the focus is on an input element
+    function isInputFocused() {
+        const activeElement = document.activeElement
+        const inputElements = ['INPUT', 'TEXTAREA', 'SELECT', 'BUTTON']
+        return activeElement && (
+            inputElements.includes(activeElement.tagName) ||
+            activeElement.getAttribute('contenteditable') === 'true' ||
+            activeElement.closest('.editorjs') !== null
+        )
+    }
+
+    // Keydown event handler
+    function handleKeyDown(event: KeyboardEvent) {
+        if (isInputFocused() || !player.value) return
+
+        const key = event.key.toLowerCase()
+
+        // Prevent default browser behavior for player control keys
+        if ([' ', 'k', 'f', 'm', 'arrowleft', 'arrowright', 'j', 'l'].includes(key)) {
+            event.preventDefault()
+        }
+
+        if (key === ' ' || key === 'k') {
+            player.value.remoteControl.togglePaused()
+        } else if (key === 'f') {
+            player.value.remoteControl.toggleFullscreen()
+        } else if (key === 'm') {
+            player.value.remoteControl.toggleMuted()
+        } else if (key === 'arrowleft' || key === 'j') {
+            player.value.remoteControl.seek(Math.max(0, player.value.currentTime - 10))
+        } else if (key === 'arrowright' || key === 'l') {
+            player.value.remoteControl.seek(Math.min(player.value.duration, player.value.currentTime + 10))
+        }
+    }
+
+    onMounted(() => {
+        window.addEventListener('keydown', handleKeyDown)
+    })
+
+    onUnmounted(() => {
+        window.removeEventListener('keydown', handleKeyDown)
+    })
+}


### PR DESCRIPTION
# Реализация глобальных горячих клавиш для видеоплеера

Реализована функциональность глобальных горячих клавиш для управления видеоплеером. Это позволяя управлять плеером, не перемещая курсор на элементы управления.

@bezumkin This PR solves that issue [https://github.com/bezumkin/orbita/issues/10](https://github.com/bezumkin/orbita/issues/10)

## Что было сделано:

1. Создан хук `useGlobalHotkeys`, который добавляет обработчики глобальных горячих клавиш.

2. Реализована проверка `isInputFocused()` для предотвращения срабатывания горячих клавиш при вводе текста в поля формы или редактировании содержимого.

3. Добавлены следующие сочетания клавиш для управления плеером:
   - **Пробел** или **K** — пауза/воспроизведение
   - **F** — полноэкранный режим
   - **M** — включение/выключение звука
   - **Стрелка влево** или **J** — перемотка на 10 секунд назад
   - **Стрелка вправо** или **L** — перемотка на 10 секунд вперед

4. Реализована корректная обработка краевых случаев:
   - Проверка на наличие активного плеера
   - Предотвращение перемотки за границы видео (меньше 0 или больше длительности)

## Технические детали:

Хук принимает реактивную ссылку на плеер и использует его API для управления воспроизведением. Интерфейс горячих клавиш соответствует стандартным клавишам YouTube, что делает взаимодействие интуитивно понятным для пользователей.